### PR TITLE
Fix link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ These are all the available features of the SDK.
                 </a>
             </td>
             <td align="left">
-                Manages user credentials between app sessions. Required if you would like to use <a href="https://github.com/trycourier/courier-android/blob/master/Docs/Inbox.md"><code>Courier Inbox</code></a> and <a href="https://github.com/trycourier/courier-ios/blob/master/Docs/PushNotifications.md"><code>Push Notifications</code></a>.
+                Manages user credentials between app sessions. Required if you would like to use <a href="https://github.com/trycourier/courier-android/blob/master/Docs/Inbox.md"><code>Courier Inbox</code></a> and <a href="https://github.com/trycourier/courier-android/blob/master/Docs/PushNotifications.md"><code>Push Notifications</code></a>.
             </td>
         </tr>
         <tr width="600px">


### PR DESCRIPTION
In the "Getting started" section, the "Push notifications" link in the descriptions column for some reason is linking to the iOS project instead of Android. One-line text change.