### PR TITLE
Add deprecation notices to Docs/ and update README links

### DIFF
--- a/Docs/Authentication.md
+++ b/Docs/Authentication.md
@@ -1,3 +1,5 @@
+> **Note**: These docs have moved to [courier.com/docs/sdk-libraries/android](https://www.courier.com/docs/sdk-libraries/android/). The content below may be outdated.
+
 # Authentication
 
 Manages user credentials between app sessions.

--- a/Docs/Client.md
+++ b/Docs/Client.md
@@ -1,3 +1,5 @@
+> **Note**: These docs have moved to [courier.com/docs/sdk-libraries/android](https://www.courier.com/docs/sdk-libraries/android/). The content below may be outdated.
+
 # `CourierClient`
 
 Base layer Courier API wrapper.

--- a/Docs/Inbox.md
+++ b/Docs/Inbox.md
@@ -1,5 +1,7 @@
 <img width="1000" alt="android-inbox-banner" src="https://github.com/trycourier/courier-android/assets/6370613/ccbe19de-5b08-4778-8f1f-c0c16f1c26e2">
 
+> **Note**: These docs have moved to [courier.com/docs/sdk-libraries/android](https://www.courier.com/docs/sdk-libraries/android/). The content below may be outdated.
+
 &emsp;
 
 &emsp;

--- a/Docs/Preferences.md
+++ b/Docs/Preferences.md
@@ -1,5 +1,7 @@
 <img width="1000" alt="android-preferences-banner" src="https://github.com/trycourier/courier-android/assets/6370613/686cd3e8-d180-4cbb-9ecb-d847526626ea">
 
+> **Note**: These docs have moved to [courier.com/docs/sdk-libraries/android](https://www.courier.com/docs/sdk-libraries/android/). The content below may be outdated.
+
 # Courier Preferences
 
 In-app notification settings that allow your users to customize which of your notifications they receive. Allows you to build high quality, flexible preference settings very quickly.

--- a/Docs/PushNotifications.md
+++ b/Docs/PushNotifications.md
@@ -1,5 +1,7 @@
 <img width="1000" alt="android-push-banner" src="https://github.com/trycourier/courier-android/assets/6370613/72159318-47d8-4d2c-ab21-30d8e8b78dea">
 
+> **Note**: These docs have moved to [courier.com/docs/sdk-libraries/android](https://www.courier.com/docs/sdk-libraries/android/). The content below may be outdated.
+
 &emsp;
 
 # Push Notifications

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ dependencies {
 
 ### 3. Initialize the SDK (Optional)
 
-If you are only using <a href="https://github.com/trycourier/courier-android/blob/master/Docs/Client.md"><code>CourierClient</code></a> APIs you can skip this step.
+If you are only using <a href="https://www.courier.com/docs/sdk-libraries/android/#courierclient"><code>CourierClient</code></a> APIs you can skip this step.
 
 ```kotlin
 // This example is on an Application class
@@ -113,12 +113,12 @@ These are all the available features of the SDK.
                 1
             </td>
             <td align="left">
-                <a href="https://github.com/trycourier/courier-android/blob/master/Docs/Authentication.md">
+                <a href="https://www.courier.com/docs/sdk-libraries/android/#authentication">
                     <code>Authentication</code>
                 </a>
             </td>
             <td align="left">
-                Manages user credentials between app sessions. Required if you would like to use <a href="https://github.com/trycourier/courier-android/blob/master/Docs/Inbox.md"><code>Inbox</code></a>, <a href="https://github.com/trycourier/courier-android/blob/master/Docs/PushNotifications.md"><code>Push Notifications</code></a> and <a href="https://github.com/trycourier/courier-android/blob/master/Docs/Preferences.md"><code>Preferences</code></a>.
+                Manages user credentials between app sessions. Required if you would like to use <a href="https://www.courier.com/docs/sdk-libraries/android/#inbox"><code>Inbox</code></a>, <a href="https://www.courier.com/docs/sdk-libraries/android/#push-notifications"><code>Push Notifications</code></a> and <a href="https://www.courier.com/docs/sdk-libraries/android/#preferences"><code>Preferences</code></a>.
             </td>
         </tr>
         <tr width="600px">
@@ -126,7 +126,7 @@ These are all the available features of the SDK.
                 2
             </td>
             <td align="left">
-                <a href="https://github.com/trycourier/courier-android/blob/master/Docs/Inbox.md">
+                <a href="https://www.courier.com/docs/sdk-libraries/android/#inbox">
                     <code>Inbox</code>
                 </a>
             </td>
@@ -139,7 +139,7 @@ These are all the available features of the SDK.
                 3
             </td>
             <td align="left">
-                <a href="https://github.com/trycourier/courier-android/blob/master/Docs/PushNotifications.md">
+                <a href="https://www.courier.com/docs/sdk-libraries/android/#push-notifications">
                     <code>Push Notifications</code>
                 </a>
             </td>
@@ -152,7 +152,7 @@ These are all the available features of the SDK.
                 4
             </td>
             <td align="left">
-                <a href="https://github.com/trycourier/courier-android/blob/master/Docs/Preferences.md">
+                <a href="https://www.courier.com/docs/sdk-libraries/android/#preferences">
                     <code>Preferences</code>
                 </a>
             </td>
@@ -165,7 +165,7 @@ These are all the available features of the SDK.
                 5
             </td>
             <td align="left">
-                <a href="https://github.com/trycourier/courier-android/blob/master/Docs/Client.md">
+                <a href="https://www.courier.com/docs/sdk-libraries/android/#courierclient">
                     <code>CourierClient</code>
                 </a>
             </td>


### PR DESCRIPTION
## Summary

- Adds deprecation notices to all 5 files in `Docs/` pointing to the canonical Mintlify docs at courier.com/docs/sdk-libraries/android/
- Updates the README "Getting Started" feature table to link to Mintlify instead of the GitHub Docs/ files