### PR TITLE
Fix Getting Started links to use correct docs/ path

### DIFF
--- a/Docs/Authentication.md
+++ b/Docs/Authentication.md
@@ -16,7 +16,7 @@ Manages user credentials between app sessions.
     <tbody>
         <tr width="600px">
             <td align="left">
-                <a href="https://github.com/trycourier/courier-android/blob/master/Docs/Inbox.md">
+                <a href="https://github.com/trycourier/courier-android/blob/main/Docs/Inbox.md">
                     <code>Inbox</code>
                 </a>
             </td>
@@ -26,7 +26,7 @@ Manages user credentials between app sessions.
         </tr>
         <tr width="600px">
             <td align="left">
-                <a href="https://github.com/trycourier/courier-android/blob/master/Docs/PushNotifications.md">
+                <a href="https://github.com/trycourier/courier-android/blob/main/Docs/PushNotifications.md">
                     <code>Push Notifications</code>
                 </a>
             </td>
@@ -36,7 +36,7 @@ Manages user credentials between app sessions.
         </tr>
         <tr width="600px">
             <td align="left">
-                <a href="https://github.com/trycourier/courier-android/blob/master/Docs/Preferences.md">
+                <a href="https://github.com/trycourier/courier-android/blob/main/Docs/Preferences.md">
                     <code>Preferences</code>
                 </a>
             </td>
@@ -51,7 +51,7 @@ Manages user credentials between app sessions.
 
 # Getting Started
 
-Put this code where you normally manage your user's state. The user's access to [`Inbox`](https://github.com/trycourier/courier-android/blob/master/Docs/Inbox.md), [`Push Notifications`](https://github.com/trycourier/courier-android/blob/master/Docs/PushNotifications.md) and [`Preferences`](https://github.com/trycourier/courier-android/blob/master/Docs/Preferences.md) will automatically be managed by the SDK and stored in persistent storage. This means that if your user fully closes your app and starts it back up, they will still be "signed in".
+Put this code where you normally manage your user's state. The user's access to [`Inbox`](https://github.com/trycourier/courier-android/blob/main/Docs/Inbox.md), [`Push Notifications`](https://github.com/trycourier/courier-android/blob/main/Docs/PushNotifications.md) and [`Preferences`](https://github.com/trycourier/courier-android/blob/main/Docs/Preferences.md) will automatically be managed by the SDK and stored in persistent storage. This means that if your user fully closes your app and starts it back up, they will still be "signed in".
 
 ⚠️ Be sure to call `Courier.initialize(context)` before `Courier.shared.signIn(...)`. [`Click here`](https://github.com/trycourier/courier-android?tab=readme-ov-file#3-initialize-the-sdk-optional) for more details.
 

--- a/Docs/Client.md
+++ b/Docs/Client.md
@@ -4,7 +4,7 @@ Base layer Courier API wrapper.
 
 ## Initialization
 
-Creating a client stores request authentication credentials only for that specific client. You can create as many clients as you'd like. See the "Going to Production" section <a href="https://github.com/trycourier/courier-android/blob/master/Docs/Authentication.md#going-to-production"><code>here</code></a> for more info.
+Creating a client stores request authentication credentials only for that specific client. You can create as many clients as you'd like. See the "Going to Production" section <a href="https://github.com/trycourier/courier-android/blob/main/Docs/Authentication.md#going-to-production"><code>here</code></a> for more info.
 
 ```kotlin
 // Creating a client

--- a/Docs/Inbox.md
+++ b/Docs/Inbox.md
@@ -30,7 +30,7 @@ An in-app notification center list you can use to notify your users. Allows you 
                 </td>
             </tr>
             <td align="left">
-                <a href="https://github.com/trycourier/courier-android/blob/master/Docs/Authentication.md">
+                <a href="https://github.com/trycourier/courier-android/blob/main/Docs/Authentication.md">
                     <code>Authentication</code>
                 </a>
             </td>
@@ -344,7 +344,7 @@ You can control your branding from the [`Courier Studio`](https://app.courier.co
 
 ---
 
-👋 `Branding APIs` can be found <a href="https://github.com/trycourier/courier-android/blob/master/Docs/Client.md#branding-apis"><code>here</code></a>
+👋 `Branding APIs` can be found <a href="https://github.com/trycourier/courier-android/blob/main/Docs/Client.md#branding-apis"><code>here</code></a>
 
 &emsp;
 
@@ -414,36 +414,36 @@ class CustomInboxFragment: Fragment(R.layout.fragment_custom_inbox) {
     <tbody>
         <tr width="600px">
             <td align="left">
-                <a href="https://github.com/trycourier/courier-android/blob/master/app/src/main/java/com/courier/example/fragments/PrebuiltInboxFragment.kt">
+                <a href="https://github.com/trycourier/courier-android/blob/main/app/src/main/java/com/courier/example/fragments/PrebuiltInboxFragment.kt">
                     <code>Default Example</code>
                 </a>
             </td>
             <td align="center">
-                <a href="https://github.com/trycourier/courier-android/blob/master/Docs/Inbox.md#default-inbox-example">
+                <a href="https://github.com/trycourier/courier-android/blob/main/Docs/Inbox.md#default-inbox-example">
                     <code>Default</code>
                 </a>
             </td>
         </tr>
         <tr width="600px">
             <td align="left">
-                <a href="https://github.com/trycourier/courier-android/blob/master/app/src/main/java/com/courier/example/fragments/StyledInboxFragment.kt">
+                <a href="https://github.com/trycourier/courier-android/blob/main/app/src/main/java/com/courier/example/fragments/StyledInboxFragment.kt">
                     <code>Styled Example</code>
                 </a>
             </td>
             <td align="center">
-                <a href="https://github.com/trycourier/courier-android/blob/master/Docs/Inbox.md#styled-inbox-example">
+                <a href="https://github.com/trycourier/courier-android/blob/main/Docs/Inbox.md#styled-inbox-example">
                     <code>Styled</code>
                 </a>
             </td>
         </tr>
         <tr width="600px">
             <td align="left">
-                <a href="https://github.com/trycourier/courier-android/blob/master/app/src/main/java/com/courier/example/fragments/CustomInboxFragment.kt">
+                <a href="https://github.com/trycourier/courier-android/blob/main/app/src/main/java/com/courier/example/fragments/CustomInboxFragment.kt">
                     <code>Custom Example</code>
                 </a>
             </td>
             <td align="center">
-                <a href="https://github.com/trycourier/courier-android/blob/master/Docs/Inbox.md#custom-inbox-example">
+                <a href="https://github.com/trycourier/courier-android/blob/main/Docs/Inbox.md#custom-inbox-example">
                     <code>Custom</code>
                 </a>
             </td>
@@ -542,4 +542,4 @@ message.actions?.first?.markAsClicked()
 
 ---
 
-👋 `Inbox APIs` can be found <a href="https://github.com/trycourier/courier-android/blob/master/Docs/Client.md#inbox-apis"><code>here</code></a>
+👋 `Inbox APIs` can be found <a href="https://github.com/trycourier/courier-android/blob/main/Docs/Client.md#inbox-apis"><code>here</code></a>

--- a/Docs/Preferences.md
+++ b/Docs/Preferences.md
@@ -16,7 +16,7 @@ In-app notification settings that allow your users to customize which of your no
     <tbody>
         <tr width="600px">
             <td align="left">
-                <a href="https://github.com/trycourier/courier-android/blob/master/Docs/Authentication.md">
+                <a href="https://github.com/trycourier/courier-android/blob/main/Docs/Authentication.md">
                     <code>Authentication</code>
                 </a>
             </td>
@@ -144,6 +144,6 @@ You can control your branding from the [`Courier Studio`](https://app.courier.co
 
 ---
 
-👋 `Branding APIs` can be found <a href="https://github.com/trycourier/courier-android/blob/master/Docs/Client.md#branding-apis"><code>here</code></a>
+👋 `Branding APIs` can be found <a href="https://github.com/trycourier/courier-android/blob/main/Docs/Client.md#branding-apis"><code>here</code></a>
 
-👋 `Preference APIs` can be found <a href="https://github.com/trycourier/courier-android/blob/master/Docs/Client.md#preferences-apis"><code>here</code></a>
+👋 `Preference APIs` can be found <a href="https://github.com/trycourier/courier-android/blob/main/Docs/Client.md#preferences-apis"><code>here</code></a>

--- a/Docs/PushNotifications.md
+++ b/Docs/PushNotifications.md
@@ -18,7 +18,7 @@ The easiest way to support push notifications in your app.
     <tbody>
         <tr width="600px">
             <td align="left">
-                <a href="https://github.com/trycourier/courier-android/blob/master/Docs/PushNotifications.md#automatic-token-syncing-fcm-only">
+                <a href="https://github.com/trycourier/courier-android/blob/main/Docs/PushNotifications.md#automatic-token-syncing-fcm-only">
                     <code>Automatic Token Management</code>
                 </a>
             </td>
@@ -28,7 +28,7 @@ The easiest way to support push notifications in your app.
         </tr>
         <tr width="600px">
             <td align="left">
-                <a href="https://github.com/trycourier/courier-android/blob/master/Docs/PushNotifications.md#manual-token-syncing">
+                <a href="https://github.com/trycourier/courier-android/blob/main/Docs/PushNotifications.md#manual-token-syncing">
                     <code>Manual Token Management</code>
                 </a>
             </td>
@@ -38,7 +38,7 @@ The easiest way to support push notifications in your app.
         </tr>
         <tr width="600px">
             <td align="left">
-                <a href="https://github.com/trycourier/courier-android/blob/master/Docs/PushNotifications.md#manual-notification-tracking">
+                <a href="https://github.com/trycourier/courier-android/blob/main/Docs/PushNotifications.md#manual-notification-tracking">
                     <code>Manual Notification Tracking</code>
                 </a>
             </td>
@@ -48,7 +48,7 @@ The easiest way to support push notifications in your app.
         </tr>
         <tr width="600px">
             <td align="left">
-                <a href="https://github.com/trycourier/courier-android/blob/master/Docs/PushNotifications.md#5-register-for-notifications">
+                <a href="https://github.com/trycourier/courier-android/blob/main/Docs/PushNotifications.md#5-register-for-notifications">
                     <code>Permission Requests & Checking</code>
                 </a>
             </td>
@@ -93,7 +93,7 @@ The easiest way to support push notifications in your app.
         </tr>
         <tr width="600px">
             <td align="left">
-                <a href="https://github.com/trycourier/courier-android/blob/master/Docs/Authentication.md">
+                <a href="https://github.com/trycourier/courier-android/blob/main/Docs/Authentication.md">
                     <code>Authentication</code>
                 </a>
             </td>
@@ -143,7 +143,7 @@ Select which push notification provider you would like Courier to route push not
                 </a>
             </td>
             <td align="center">
-                <a href="https://github.com/trycourier/courier-android/blob/master/Docs/PushNotifications.md#automatic-token-syncing-fcm-only">
+                <a href="https://github.com/trycourier/courier-android/blob/main/Docs/PushNotifications.md#automatic-token-syncing-fcm-only">
                      <code>Automatic</code>
                 </a>
             </td>
@@ -155,7 +155,7 @@ Select which push notification provider you would like Courier to route push not
                 </a>
             </td>
             <td align="center">
-                <a href="https://github.com/trycourier/courier-android/blob/master/Docs/PushNotifications.md#manual-token-syncing">
+                <a href="https://github.com/trycourier/courier-android/blob/main/Docs/PushNotifications.md#manual-token-syncing">
                     <code>Manual</code>
                 </a>
             </td>
@@ -167,7 +167,7 @@ Select which push notification provider you would like Courier to route push not
                 </a>
             </td>
             <td align="center">
-                <a href="https://github.com/trycourier/courier-android/blob/master/Docs/PushNotifications.md#manual-token-syncing">
+                <a href="https://github.com/trycourier/courier-android/blob/main/Docs/PushNotifications.md#manual-token-syncing">
                     <code>Manual</code>
                 </a>
             </td>
@@ -179,7 +179,7 @@ Select which push notification provider you would like Courier to route push not
                 </a>
             </td>
             <td align="center">
-                <a href="https://github.com/trycourier/courier-android/blob/master/Docs/PushNotifications.md#manual-token-syncing">
+                <a href="https://github.com/trycourier/courier-android/blob/main/Docs/PushNotifications.md#manual-token-syncing">
                     <code>Manual</code>
                 </a>
             </td>
@@ -311,7 +311,7 @@ Token syncing is required for push notifications to work. Your `FirebaseMessagin
 | `onNewToken(token)` | `Courier.onNewToken(token)` | Caches the FCM token locally and uploads it to Courier for the current user |
 | `onMessageReceived(message)` | `Courier.onMessageReceived(message.data)` | Tracks the delivery event and broadcasts it through the SDK event bus |
 
-See the working example: [`ExampleService.kt`](https://github.com/trycourier/courier-android/blob/master/app/src/main/java/com/courier/example/ExampleService.kt)
+See the working example: [`ExampleService.kt`](https://github.com/trycourier/courier-android/blob/main/app/src/main/java/com/courier/example/ExampleService.kt)
 
 ### Reading and Refreshing Tokens
 
@@ -329,7 +329,7 @@ lifecycleScope.launch {
 }
 ```
 
-See the working example: [`PushFragment.kt`](https://github.com/trycourier/courier-android/blob/master/app/src/main/java/com/courier/example/fragments/PushFragment.kt)
+See the working example: [`PushFragment.kt`](https://github.com/trycourier/courier-android/blob/main/app/src/main/java/com/courier/example/fragments/PushFragment.kt)
 
 ### Non-FCM Providers
 
@@ -379,7 +379,7 @@ lifecycleScope.launch {
 
 This will take the tokens you are syncing above and upload them to the `userId` you provide here.
 
-See [`Authentication`](https://github.com/trycourier/courier-android/blob/master/Docs/Authentication.md) for more details.
+See [`Authentication`](https://github.com/trycourier/courier-android/blob/main/Docs/Authentication.md) for more details.
 
 ```kotlin
 lifecycleScope.launch {
@@ -432,4 +432,4 @@ val isGranted = Courier.shared.isPushPermissionGranted(context)
 
 ---
 
-👋 `TokenManagement APIs` can be found <a href="https://github.com/trycourier/courier-android/blob/master/Docs/Client.md#token-management-apis"><code>here</code></a>
+👋 `TokenManagement APIs` can be found <a href="https://github.com/trycourier/courier-android/blob/main/Docs/Client.md#token-management-apis"><code>here</code></a>

--- a/README.md
+++ b/README.md
@@ -84,12 +84,12 @@ These are all the available features of the SDK.
                 1
             </td>
             <td align="left">
-                <a href="https://github.com/trycourier/courier-android/blob/master/docs/Authentication.md">
+                <a href="https://github.com/trycourier/courier-android/blob/main/Docs/Authentication.md">
                     <code>Authentication</code>
                 </a>
             </td>
             <td align="left">
-                Manages user credentials between app sessions. Required if you would like to use <a href="https://github.com/trycourier/courier-android/blob/master/docs/Inbox.md"><code>Inbox</code></a>, <a href="https://github.com/trycourier/courier-android/blob/master/docs/PushNotifications.md"><code>Push Notifications</code></a> and <a href="https://github.com/trycourier/courier-android/blob/master/docs/Preferences.md"><code>Preferences</code></a>.
+                Manages user credentials between app sessions. Required if you would like to use <a href="https://github.com/trycourier/courier-android/blob/main/Docs/Inbox.md"><code>Inbox</code></a>, <a href="https://github.com/trycourier/courier-android/blob/main/Docs/PushNotifications.md"><code>Push Notifications</code></a> and <a href="https://github.com/trycourier/courier-android/blob/main/Docs/Preferences.md"><code>Preferences</code></a>.
             </td>
         </tr>
         <tr width="600px">
@@ -97,7 +97,7 @@ These are all the available features of the SDK.
                 2
             </td>
             <td align="left">
-                <a href="https://github.com/trycourier/courier-android/blob/master/docs/Inbox.md">
+                <a href="https://github.com/trycourier/courier-android/blob/main/Docs/Inbox.md">
                     <code>Inbox</code>
                 </a>
             </td>
@@ -110,7 +110,7 @@ These are all the available features of the SDK.
                 3
             </td>
             <td align="left">
-                <a href="https://github.com/trycourier/courier-android/blob/master/docs/PushNotifications.md">
+                <a href="https://github.com/trycourier/courier-android/blob/main/Docs/PushNotifications.md">
                     <code>Push Notifications</code>
                 </a>
             </td>
@@ -123,7 +123,7 @@ These are all the available features of the SDK.
                 4
             </td>
             <td align="left">
-                <a href="https://github.com/trycourier/courier-android/blob/master/docs/Preferences.md">
+                <a href="https://github.com/trycourier/courier-android/blob/main/Docs/Preferences.md">
                     <code>Preferences</code>
                 </a>
             </td>
@@ -136,7 +136,7 @@ These are all the available features of the SDK.
                 5
             </td>
             <td align="left">
-                <a href="https://github.com/trycourier/courier-android/blob/master/docs/Client.md">
+                <a href="https://github.com/trycourier/courier-android/blob/main/Docs/Client.md">
                     <code>CourierClient</code>
                 </a>
             </td>
@@ -153,7 +153,7 @@ These are all the available features of the SDK.
 
 Here is what the Courier Android SDK automatically handles with Proguard:
 
-<a href="https://github.com/trycourier/courier-android/blob/master/android/consumer-rules.pro">
+<a href="https://github.com/trycourier/courier-android/blob/main/android/consumer-rules.pro">
     <code>Proguard Rules</code>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -84,12 +84,12 @@ These are all the available features of the SDK.
                 1
             </td>
             <td align="left">
-                <a href="https://github.com/trycourier/courier-android/blob/master/Docs/Authentication.md">
+                <a href="https://github.com/trycourier/courier-android/blob/master/docs/Authentication.md">
                     <code>Authentication</code>
                 </a>
             </td>
             <td align="left">
-                Manages user credentials between app sessions. Required if you would like to use <a href="https://github.com/trycourier/courier-android/blob/master/Docs/Inbox.md"><code>Inbox</code></a>, <a href="https://github.com/trycourier/courier-android/blob/master/Docs/PushNotifications.md"><code>Push Notifications</code></a> and <a href="https://github.com/trycourier/courier-android/blob/master/Docs/Preferences.md"><code>Preferences</code></a>.
+                Manages user credentials between app sessions. Required if you would like to use <a href="https://github.com/trycourier/courier-android/blob/master/docs/Inbox.md"><code>Inbox</code></a>, <a href="https://github.com/trycourier/courier-android/blob/master/docs/PushNotifications.md"><code>Push Notifications</code></a> and <a href="https://github.com/trycourier/courier-android/blob/master/docs/Preferences.md"><code>Preferences</code></a>.
             </td>
         </tr>
         <tr width="600px">
@@ -97,7 +97,7 @@ These are all the available features of the SDK.
                 2
             </td>
             <td align="left">
-                <a href="https://github.com/trycourier/courier-android/blob/master/Docs/Inbox.md">
+                <a href="https://github.com/trycourier/courier-android/blob/master/docs/Inbox.md">
                     <code>Inbox</code>
                 </a>
             </td>
@@ -110,7 +110,7 @@ These are all the available features of the SDK.
                 3
             </td>
             <td align="left">
-                <a href="https://github.com/trycourier/courier-android/blob/master/Docs/PushNotifications.md">
+                <a href="https://github.com/trycourier/courier-android/blob/master/docs/PushNotifications.md">
                     <code>Push Notifications</code>
                 </a>
             </td>
@@ -123,7 +123,7 @@ These are all the available features of the SDK.
                 4
             </td>
             <td align="left">
-                <a href="https://github.com/trycourier/courier-android/blob/master/Docs/Preferences.md">
+                <a href="https://github.com/trycourier/courier-android/blob/master/docs/Preferences.md">
                     <code>Preferences</code>
                 </a>
             </td>
@@ -136,7 +136,7 @@ These are all the available features of the SDK.
                 5
             </td>
             <td align="left">
-                <a href="https://github.com/trycourier/courier-android/blob/master/Docs/Client.md">
+                <a href="https://github.com/trycourier/courier-android/blob/master/docs/Client.md">
                     <code>CourierClient</code>
                 </a>
             </td>


### PR DESCRIPTION
## Summary
- Updated 8 links in the README Getting Started section from `Docs/` (capital D) to `docs/` (lowercase d) to match the proper directory path


Made with [Cursor](https://cursor.com)