### PR TITLE
Fix InboxListView NPE when switching tabs

### DIFF
--- a/android/src/main/java/com/courier/android/ui/inbox/InboxListView.kt
+++ b/android/src/main/java/com/courier/android/ui/inbox/InboxListView.kt
@@ -395,23 +395,26 @@ internal class InboxListView @JvmOverloads constructor(
             return@launch
         }
 
-        // Resolve visible indexes + snapshot messages on the main thread
+        // Resolve visible items on the main thread. RecyclerView/LayoutManager
+        // state and the adapter list are both confined to the main thread, so
+        // these reads are safe and cheap (visible children are bounded).
         val manager = layoutManager ?: return@launch
         val firstIndex = manager.findFirstCompletelyVisibleItemPosition()
         val lastIndex = manager.findLastCompletelyVisibleItemPosition()
-
         if (firstIndex == -1 || lastIndex == -1) {
             return@launch
         }
 
-        val snapshot = messagesAdapter.messages.toList()
+        val messages = messagesAdapter.messages
         val safeFirst = firstIndex.coerceAtLeast(0)
-        val safeLast = lastIndex.coerceAtMost(snapshot.size)
+        val safeLast = lastIndex.coerceAtMost(messages.size)
         if (safeFirst >= safeLast) {
             return@launch
         }
 
-        val messagesToOpen = snapshot.subList(safeFirst, safeLast).filter { !it.isOpened }
+        // .filter produces a new List, so it's safe to pass into the IO block
+        // even if the underlying adapter list mutates afterwards.
+        val messagesToOpen = messages.subList(safeFirst, safeLast).filter { !it.isOpened }
         if (messagesToOpen.isEmpty()) {
             return@launch
         }

--- a/android/src/main/java/com/courier/android/ui/inbox/InboxListView.kt
+++ b/android/src/main/java/com/courier/android/ui/inbox/InboxListView.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 internal class InboxListView @JvmOverloads constructor(
     context: Context,
@@ -382,52 +383,48 @@ internal class InboxListView @JvmOverloads constructor(
     }
 
     // Opens all the current messages
-    // Performs this on an async thread
-    // Fails silently
-    private fun openVisibleMessages() = coroutineScope.launch(Dispatchers.IO) {
+    // Resolves visible items on the main thread (RecyclerView/LayoutManager state is
+    // not thread-safe and reading it from a worker thread races with the layout
+    // pass — most easily reproduced when switching tabs while the list is settling,
+    // which produced a NullPointerException inside ViewBoundsCheck).
+    // Network calls are then dispatched to IO. Fails silently.
+    private fun openVisibleMessages() = coroutineScope.launch(Dispatchers.Main) {
 
         // Ensure we have a user and messages to look through
         if (!Courier.shared.isUserSignedIn || mutatedMessageId != null || messagesAdapter.messages.isEmpty()) {
             return@launch
         }
 
-        // Get all the visible items
-        layoutManager?.let { manager ->
+        // Resolve visible indexes + snapshot messages on the main thread
+        val manager = layoutManager ?: return@launch
+        val firstIndex = manager.findFirstCompletelyVisibleItemPosition()
+        val lastIndex = manager.findLastCompletelyVisibleItemPosition()
 
-            // Get the indexes
-            val firstIndex = manager.findFirstCompletelyVisibleItemPosition()
-            val lastIndex = manager.findLastCompletelyVisibleItemPosition()
+        if (firstIndex == -1 || lastIndex == -1) {
+            return@launch
+        }
 
-            // Avoid index out of bounds
-            if (firstIndex == -1 || lastIndex == -1) {
-                return@let
-            }
+        val snapshot = messagesAdapter.messages.toList()
+        val safeFirst = firstIndex.coerceAtLeast(0)
+        val safeLast = lastIndex.coerceAtMost(snapshot.size)
+        if (safeFirst >= safeLast) {
+            return@launch
+        }
 
+        val messagesToOpen = snapshot.subList(safeFirst, safeLast).filter { !it.isOpened }
+        if (messagesToOpen.isEmpty()) {
+            return@launch
+        }
+
+        // Run network work off the main thread
+        withContext(Dispatchers.IO) {
             try {
-
-                // Find the messages
-                val messagesToOpen = messagesAdapter.messages.subList(firstIndex, lastIndex).filter { !it.isOpened }.map { message ->
-
-                    if (message.isOpened) {
-                        return@map null
-                    }
-
-                    // Mark the message as opened
-                    return@map async {
-                        message.markAsOpened()
-                    }
-
-                }
-
-                // Perform all the changes together
-                messagesToOpen.filterNotNull().awaitAll()
-
+                messagesToOpen.map { message ->
+                    async { message.markAsOpened() }
+                }.awaitAll()
             } catch (e: Exception) {
-
                 Courier.shared.client?.error(e.message)
-
             }
-
         }
 
     }


### PR DESCRIPTION
## Summary

`openVisibleMessages` was launched on `Dispatchers.IO` and called `LinearLayoutManager.findFirstCompletelyVisibleItemPosition()` / `findLastCompletelyVisibleItemPosition()` from a worker thread. Those APIs walk `RecyclerView` children and read `View.getLayoutParams()`, which is not thread-safe and races with the layout pass. Switching tabs while the list was still settling reliably reproduced a fatal `NullPointerException` inside `ViewBoundsCheck.findOneViewWithinBoundFlags`:

```
FATAL EXCEPTION: DefaultDispatcher-worker-6
java.lang.NullPointerException: Attempt to invoke virtual method
'android.view.ViewGroup$LayoutParams android.view.View.getLayoutParams()'
on a null object reference
  at androidx.recyclerview.widget.RecyclerView$LayoutManager$2.getChildStart(RecyclerView.java:8467)
  at androidx.recyclerview.widget.ViewBoundsCheck.findOneViewWithinBoundFlags(ViewBoundsCheck.java:219)
  at androidx.recyclerview.widget.LinearLayoutManager.findOneVisibleChild(LinearLayoutManager.java:2065)
  at androidx.recyclerview.widget.LinearLayoutManager.findLastCompletelyVisibleItemPosition(LinearLayoutManager.java:2038)
  at com.courier.android.ui.inbox.InboxListView$openVisibleMessages$1.invokeSuspend(InboxListView.kt:399)
```

## Fix

- Switch the outer coroutine to `Dispatchers.Main` so `LayoutManager` and adapter reads happen on the UI thread.
- Read the visible index range, then `subList(...).filter { !it.isOpened }` on the main thread. `Iterable.filter` returns a fresh list, so it's safe to hand off to IO even if the adapter mutates afterwards.
- Defensively bound the visible range with `coerceAtLeast(0)` / `coerceAtMost(messages.size)` against stale indexes.
- Move only the network work (`message.markAsOpened()`) to `Dispatchers.IO` via `withContext`.

## Performance

The fix is essentially free on the main thread:

- `findFirst/LastCompletelyVisibleItemPosition()` walk visible children only (~10–30 views), microseconds.
- `subList(...).filter { !it.isOpened }` iterates only the visible slice.
- Early return when nothing new is visible — no IO hop in the steady state.

A `.toList()` snapshot was tried in the first commit but dropped in the follow-up: it added O(totalMessages) main-thread work on every scroll event for no benefit, since adapter mutations are also confined to the main thread now.

## Pre-existing follow-up (not in this PR)

`recyclerView.setOnScrollChangeListener` fires on every pixel of scroll, so a flick can launch dozens of `openVisibleMessages` coroutines per second. They mostly no-op via the early-exit, but the launches themselves aren't free. Worth throttling/debouncing or migrating to `RecyclerView.OnScrollListener` with `onScrollStateChanged` in a separate change.

## Test plan

- [ ] Open the example app inbox, switch tabs rapidly while messages are loading — no longer crashes.
- [ ] Scroll the list and confirm visible messages are still marked as opened.
- [ ] Confirm `setInbox`, `addPage`, `addMessage`, `removeMessage`, and the scroll listener still call into `openVisibleMessages` cleanly (no thread-confinement asserts).
- [ ] Profile a fast scroll — main thread stays well under the 16ms frame budget.
