### PR TITLE
Bump version to 6.0.1 and add inbox theme background overrides

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -15,6 +15,7 @@
       </map>
     </option>
   </component>
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="corretto-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>

--- a/Docs/Inbox.md
+++ b/Docs/Inbox.md
@@ -165,6 +165,9 @@ fun getTheme(context: Context): CourierInboxTheme {
     val font = ResourcesCompat.getFont(context, R.font.poppins)
 
     return CourierInboxTheme(
+        backgroundColor = whiteColor,
+        listItemBackgroundColor = whiteColor,
+        tabBackgroundColor = whiteColor,
         loadingIndicatorColor = primaryColor,
         tabIndicatorColor = primaryColor,
         tabStyle = CourierStyles.Inbox.TabStyle(

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Add the dependency to your app's `build.gradle`:
 
 ```gradle
 dependencies {
-    implementation 'com.github.trycourier:courier-android:6.0.0' // Groovy
-    implementation("com.github.trycourier:courier-android:6.0.0") // Gradle.kts
+    implementation 'com.github.trycourier:courier-android:6.0.1' // Groovy
+    implementation("com.github.trycourier:courier-android:6.0.1") // Gradle.kts
 }
 ```
 

--- a/android/src/main/java/com/courier/android/Courier.kt
+++ b/android/src/main/java/com/courier/android/Courier.kt
@@ -59,7 +59,7 @@ class Courier private constructor(val context: Context) : Application.ActivityLi
     companion object {
 
         // Core
-        private const val VERSION = "6.0.0"
+        private const val VERSION = "6.0.1"
         var agent: CourierAgent = CourierAgent.NativeAndroid(VERSION)
 
         // Inbox

--- a/android/src/main/java/com/courier/android/ui/inbox/CourierInbox.kt
+++ b/android/src/main/java/com/courier/android/ui/inbox/CourierInbox.kt
@@ -214,6 +214,7 @@ open class CourierInbox @JvmOverloads constructor(context: Context, attrs: Attri
 
     private fun reloadViews() {
         theme.backgroundColor?.let { setBackgroundColor(it) }
+        theme.tabBackgroundColor?.let { tabLayout.setBackgroundColor(it) }
         pages.forEach { it.list.theme = theme }
         setupViewPager()
     }

--- a/android/src/main/java/com/courier/android/ui/inbox/CourierInboxTheme.kt
+++ b/android/src/main/java/com/courier/android/ui/inbox/CourierInboxTheme.kt
@@ -15,6 +15,8 @@ import com.courier.android.utils.error
 data class CourierInboxTheme(
     val brandId: String? = null,
     @ColorInt val backgroundColor: Int? = null,
+    @ColorInt val listItemBackgroundColor: Int? = null,
+    @ColorInt val tabBackgroundColor: Int? = null,
     @ColorInt internal val tabIndicatorColor: Int? = null,
     internal val tabStyle: CourierStyles.Inbox.TabStyle = CourierStyles.Inbox.TabStyle(
         selected = CourierStyles.Inbox.TabItemStyle(

--- a/android/src/main/java/com/courier/android/ui/inbox/MessagesAdapter.kt
+++ b/android/src/main/java/com/courier/android/ui/inbox/MessagesAdapter.kt
@@ -72,6 +72,10 @@ internal class MessageItemViewHolder(itemView: View) : RecyclerView.ViewHolder(i
         timeTextView.text = message.time
         subtitleTextView.text = message.subtitle
 
+        theme.listItemBackgroundColor?.let {
+            container.setBackgroundColor(it)
+        }
+
         // Indicator
         setIndicator(theme, message)
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,7 +20,7 @@ android {
         applicationId "com.courier.example_app"
         minSdk 23
         targetSdk 35
-        versionCode 69
+        versionCode 70
         versionName "1.0"
         signingConfig signingConfigs.debug
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/com/courier/example/ExampleService.kt
+++ b/app/src/main/java/com/courier/example/ExampleService.kt
@@ -16,6 +16,7 @@ class ExampleService: FirebaseMessagingService() {
 
         // Create the PendingIntent that runs when the user taps the notification
         // This intent targets your Activity and carries the original message payload
+        // TODO: Remove this if you'd like. This is mostly useful for demo purposes.
         val notificationIntent = CourierPushNotificationIntent(
             context = this,
             target = MainActivity::class.java,
@@ -25,6 +26,7 @@ class ExampleService: FirebaseMessagingService() {
         // Show the notification to the user.
         // Prefer data-only FCM so this service runs even in background/killed state.
         // Fall back to notification fields if data keys are missing.
+        // TODO: Remove this if you'd like. This is mostly useful for demo purposes.
         notificationIntent.presentNotification(
             title = message.data["title"] ?: message.notification?.title,
             body = message.data["body"] ?: message.notification?.body,


### PR DESCRIPTION
## Summary
- Bump SDK `VERSION` constant from `6.0.0` to `6.0.1`
- Update README install snippet to `6.0.1`
- Bump example app `versionCode` from `69` to `70`
- Add `listItemBackgroundColor` and `tabBackgroundColor` to `CourierInboxTheme` for independent theming of list rows and the tab strip
- Document `backgroundColor`, `listItemBackgroundColor`, and `tabBackgroundColor` in the styled inbox example in `Docs/Inbox.md`

## Test plan
- [x] Verify `Courier.VERSION` reports `6.0.1` at runtime
- [x] Confirm example app builds and installs with new `versionCode`
- [x] README install snippet copy/paste works against latest release
- [x] Set `listItemBackgroundColor` in a `CourierInboxTheme` and confirm rows render with that color
- [x] Set `tabBackgroundColor` in a `CourierInboxTheme` and confirm the tab strip renders with that color
- [x] Themes that don't set the new fields render unchanged