### PR TITLE
chore(example): clarify ExampleService demo vs. Courier integration comments

### DIFF
--- a/app/src/main/java/com/courier/example/ExampleService.kt
+++ b/app/src/main/java/com/courier/example/ExampleService.kt
@@ -6,27 +6,47 @@ import com.courier.android.notifications.presentNotification
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 
+// This is a working FirebaseMessagingService used by the example app.
+// Only two Courier SDK calls are required to integrate push tracking:
+//   1. Courier.onMessageReceived(...)   — in onMessageReceived
+//   2. Courier.onNewToken(...)          — in onNewToken
+//
+// Everything below those calls (CourierPushNotificationIntent, presentNotification)
+// is demo code that puts a basic notification on screen for testing.
+// In a production app you would replace that block with your own
+// NotificationCompat.Builder implementation.
+//
+// Docs:
+//   Courier Android SDK    — https://www.courier.com/docs/sdk-libraries/android
+//   Android notifications  — https://developer.android.com/develop/ui/views/notifications/build-notification
 class ExampleService: FirebaseMessagingService() {
 
     override fun onMessageReceived(message: RemoteMessage) {
         super.onMessageReceived(message)
 
-        // Notify the Courier SDK that a push was delivered
+        // Required — Tells the Courier SDK a push was delivered.
+        // Behind the scenes this posts the trackingUrl from the FCM data payload
+        // as a DELIVERED event so delivery analytics appear in the Courier dashboard,
+        // and fires any onPushDelivered listeners registered via Courier.shared.
         Courier.onMessageReceived(message.data)
 
-        // Create the PendingIntent that runs when the user taps the notification
-        // This intent targets your Activity and carries the original message payload
-        // TODO: Remove this if you'd like. This is mostly useful for demo purposes.
+        // --- Demo notification code (replace with your own for production) -----------
+        //
+        // CourierPushNotificationIntent is a convenience wrapper that bundles the
+        // RemoteMessage into a PendingIntent. When the user taps the notification,
+        // Courier can fire onPushNotificationClicked and track a CLICKED event.
+        // In your own app you can build the PendingIntent yourself and call
+        // Courier.shared.client.tracking.postTrackingUrl(...) on tap instead.
         val notificationIntent = CourierPushNotificationIntent(
             context = this,
             target = MainActivity::class.java,
             payload = message
         )
 
-        // Show the notification to the user.
-        // Prefer data-only FCM so this service runs even in background/killed state.
-        // Fall back to notification fields if data keys are missing.
-        // TODO: Remove this if you'd like. This is mostly useful for demo purposes.
+        // presentNotification is a Courier helper that posts a basic notification
+        // via NotificationManagerCompat. It is fine for testing but not customizable
+        // enough for production — use NotificationCompat.Builder directly:
+        // https://developer.android.com/develop/ui/views/notifications/build-notification
         notificationIntent.presentNotification(
             title = message.data["title"] ?: message.notification?.title,
             body = message.data["body"] ?: message.notification?.body,
@@ -37,8 +57,10 @@ class ExampleService: FirebaseMessagingService() {
     override fun onNewToken(token: String) {
         super.onNewToken(token)
 
-        // Register/refresh this device’s FCM token with Courier.
-        // The SDK caches and updates the token automatically and links it to the current user.
+        // Required — Syncs this device's FCM token with Courier.
+        // Behind the scenes the SDK caches the token locally and uploads it to
+        // Courier linked to the currently signed-in user. If no user is signed in
+        // yet the token is held locally and synced on the next signIn() call.
         Courier.onNewToken(token)
 
     }


### PR DESCRIPTION
## Summary
- Rewrite comments in the demo `ExampleService.kt` so developers can clearly see the two required Courier SDK calls vs. the demo notification rendering.
- Document what `Courier.onMessageReceived` and `Courier.onNewToken` do behind the scenes (delivery tracking + token sync).
- Mark the `CourierPushNotificationIntent` + `presentNotification` block as demo-only and point to `NotificationCompat.Builder` for production.
- Link to the relevant Courier Android and Android notification docs from the file header.
- No behavior changes. No build/version changes.

Made with [Cursor](https://cursor.com)