### PR TITLE
chore: bump SDK version to 6.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Add the dependency to your app's `build.gradle`:
 
 ```gradle
 dependencies {
-    implementation 'com.github.trycourier:courier-android:LATEST_VERSION'
+    implementation 'com.github.trycourier:courier-android:6.1.1'
 }
 ```
 

--- a/android/src/main/java/com/courier/android/Courier.kt
+++ b/android/src/main/java/com/courier/android/Courier.kt
@@ -61,7 +61,7 @@ class Courier private constructor(val context: Context) : Application.ActivityLi
     companion object {
 
         // Core
-        private const val VERSION = "6.1.0"
+        private const val VERSION = "6.1.1"
         var agent: CourierAgent = CourierAgent.NativeAndroid(VERSION)
 
         // Inbox

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,7 +20,7 @@ android {
         applicationId "com.courier.example_app"
         minSdk 23
         targetSdk 35
-        versionCode 71
+        versionCode 72
         versionName "1.0"
         signingConfig signingConfigs.debug
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
## Summary
- Bump Courier Android SDK version from 6.1.0 to 6.1.1
- Update `Courier.kt`, README dependency references, and example app `versionCode`

## Test plan
- [ ] CI passes
- [ ] Example app builds successfully


Made with [Cursor](https://cursor.com)